### PR TITLE
Prefer use display_name wherever possible

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ mod test_readme {
     #![doc = include_str!("../README.md")]
 }
 
-
 use std::fmt::{self, Write};
 
 use clap::builder::PossibleValue;
@@ -65,7 +64,7 @@ fn write_help_markdown(buffer: &mut String, command: &clap::Command) {
     writeln!(
         buffer,
         "This document contains the help content for the `{}` command-line program.\n",
-        command.get_name()
+        command.get_display_name().unwrap_or_else(|| command.get_name())
     ).unwrap();
 
     //----------------------------------
@@ -117,7 +116,12 @@ fn build_table_of_contents_markdown(
     // Append the name of `command` to `command_path`.
     let command_path = {
         let mut command_path = parent_command_path;
-        command_path.push(command.get_name().to_owned());
+        command_path.push(
+            command
+                .get_display_name()
+                .unwrap_or_else(|| command.get_name())
+                .to_owned(),
+        );
         command_path
     };
 
@@ -205,7 +209,12 @@ fn build_command_markdown(
     // Append the name of `command` to `command_path`.
     let command_path = {
         let mut command_path = parent_command_path.clone();
-        command_path.push(command.get_name().to_owned());
+        command_path.push(
+            command
+                .get_display_name()
+                .unwrap_or_else(|| command.get_name())
+                .to_owned(),
+        );
         command_path
     };
 
@@ -273,7 +282,9 @@ fn build_command_markdown(
             writeln!(
                 buffer,
                 "* `{}` — {}",
-                subcommand.get_name(),
+                subcommand
+                    .get_display_name()
+                    .unwrap_or_else(|| subcommand.get_name()),
                 match subcommand.get_about() {
                     Some(about) => about.to_string(),
                     None => String::new(),


### PR DESCRIPTION
The current implementation of `clap_markdown` mixes `get_name()` and `get_display_name()` methods to acquire the base name of the command being documented. This PR ensures that `display_name` is always preferred unless not set.
